### PR TITLE
Fix nvis.sh to work with python2

### DIFF
--- a/bin/nvis.sh
+++ b/bin/nvis.sh
@@ -5,6 +5,12 @@ NVIS_DIR=${SCRIPT_DIR%/*}
 SERVER=http.server
 #SERVER=RangeHTTPServer
 
-#PYTHON_VERSION=`python --version`
+PYTHON_VERSION=`python --version`
 echo [Nvis]  Starting HTTP server on port ${PORT} in ${NVIS_DIR}
-python -m http.server --bind localhost ${PORT} -d ${NVIS_DIR}/
+PYTHON_MAJOR=${PYTHON_VERSION%%.*}
+if [[ $PYTHON_MAJOR -lt 3 ]]; then
+    cd ${NVIS_DIR}
+    python -m SimpleHTTPServer ${PORT}
+else
+    python -m http.server --bind localhost ${PORT} -d ${NVIS_DIR}/
+fi


### PR DESCRIPTION
My system only has python 2 installed and so the nvis.sh script doesn't work out of the box. This adds a check for the python version and then uses the appropriate way of getting the built-in http server running..